### PR TITLE
Use Python 3.9 type hinting generics

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -1,19 +1,17 @@
-from typing import List
-
 from pydantic import BaseModel
 
 
 class MaskinportenClientIn(BaseModel):
     name: str
     description: str
-    scopes: List[str]
+    scopes: list[str]
 
 
 class MaskinportenClientOut(BaseModel):
     client_id: str
     name: str
     description: str
-    scopes: List[str]
+    scopes: list[str]
 
 
 class ClientKey(BaseModel):

--- a/resources/maskinporten_clients.py
+++ b/resources/maskinporten_clients.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from typing import List
 
 from fastapi import APIRouter, status
 
@@ -43,7 +42,7 @@ def create_client_key(client_id: str):
 @router.get(
     "/{client_id}/keys",
     status_code=status.HTTP_200_OK,
-    response_model=List[ClientKeyMetadata],
+    response_model=list[ClientKeyMetadata],
 )
 def list_client_keys(client_id: str):
     # TODO: Implement real functionality


### PR DESCRIPTION
Now that we're on Python 3.9, we can use the type hinting generics [introduced there](https://docs.python.org/3/whatsnew/3.9.html#type-hinting-generics-in-standard-collections), instead of the `typing` module.