### PR TITLE
Include `maskinporten_api` in Serverless bundle

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -34,9 +34,9 @@ package:
   include:
     - app.py
     - handler.py
-    - resources/*.py
+    - maskinporten_api/*.py
     - models/*.py
-
+    - resources/*.py
 
 functions:
   app:


### PR DESCRIPTION
Fix import errors by including the `maskinporten_api` directory in the Serverless bundle.