### PR TITLE
Drop dedicated `maskinporten-key` resource type

### DIFF
--- a/maskinporten_api/util.py
+++ b/maskinporten_api/util.py
@@ -12,3 +12,7 @@ def getenv(name):
         raise OSError(f"Environment variable {name} is not set")
 
     return env
+
+
+def sanitize(log_entry):
+    return log_entry.replace("\n", "")

--- a/resources/maskinporten_clients.py
+++ b/resources/maskinporten_clients.py
@@ -177,13 +177,6 @@ def create_client_key(
 
     kid = jwks["keys"][0]["kid"]
 
-    # TODO: Roll back created client if permission creation fails.
-    create_okdata_permissions(
-        resource_name=f"okdata:maskinporten-key:{env}-{client_id}-key-{kid}",
-        owner_principal_id=auth_info.principal_id,
-        auth_header=service_client.authorization_header,
-    )
-
     audit_log(
         item_id=kid,
         item_type="key",

--- a/resources/maskinporten_clients.py
+++ b/resources/maskinporten_clients.py
@@ -25,13 +25,13 @@ from maskinporten_api.maskinporten_client import (
     TooManyKeysError,
     UnsupportedEnvironmentError,
 )
-
 from maskinporten_api.permissions import create_okdata_permissions
 from maskinporten_api.ssm import (
     SendSecretsService,
     Secrets,
     AssumeRoleAccessDeniedException,
 )
+from maskinporten_api.util import sanitize
 from resources.authorizer import AuthInfo, authorize, ServiceClient
 from resources.errors import error_message_models, ErrorResponse
 
@@ -58,7 +58,9 @@ def create_client(
     service_client: ServiceClient = Depends(),
 ):
     logger.debug(
-        f"Creating new client '{body.name}' in {body.env} with scopes {body.scopes}"
+        sanitize(
+            f"Creating new client '{body.name}' in {body.env} with scopes {body.scopes}"
+        )
     )
     try:
         new_client = MaskinportenClient(body.env).create_client(body)
@@ -150,7 +152,9 @@ def create_client_key(
     jwk = jwk_from_key(key)
     key_id = jwk["kid"]
 
-    logger.debug(f"Registering new key with id {key_id} for client {client_id}")
+    logger.debug(
+        sanitize(f"Registering new key with id {key_id} for client {client_id}")
+    )
 
     key_password = generate_password(pw_length=32)
 

--- a/test/resources/test_maskinporten_clients.py
+++ b/test/resources/test_maskinporten_clients.py
@@ -135,9 +135,6 @@ def test_create_client_key(
             f"{CLIENTS_ENDPOINT}{client_id}/jwks",
             json=maskinporten_create_client_key_response,
         )
-        permissions_adapter = rm.post(
-            f"{OKDATA_PERMISSION_API_URL}/permissions",
-        )
 
         destination_aws_account = "123456789876"
         destination_aws_region = "eu-west-1"
@@ -165,13 +162,6 @@ def test_create_client_key(
     table = mock_dynamodb.Table("maskinporten-audit-trail")
     audit_log_entry = table.get_item(Key={"Id": key["kid"], "Type": "key"})
     assert audit_log_entry["Item"]["Id"] == key["kid"]
-
-    permissions_request = permissions_adapter.last_request
-    assert permissions_request.headers["Authorization"] == f"Bearer {valid_token}"
-    assert permissions_request.json() == {
-        "owner": {"user_id": username, "user_type": "user"},
-        "resource_name": f"okdata:maskinporten-key:test-{client_id}-key-{key['kid']}",
-    }
 
 
 def test_create_client_key_too_many_keys(


### PR DESCRIPTION
Let's check for `write` permission on the `maskinporten-client` instead.