### PR TITLE
T#168 Roll back MP client on permission API fail

### DIFF
--- a/maskinporten_api/maskinporten_client.py
+++ b/maskinporten_api/maskinporten_client.py
@@ -119,6 +119,9 @@ class MaskinportenClient:
     def get_clients(self):
         return self._request("GET", ["idporten:dcr.read"])
 
+    def delete_client(self, client_id: str):
+        return self._request("DELETE", ["idporten:dcr.write"], client_id)
+
     def create_client_key(self, client_id: str, jwk: dict):
         existing_jwks = self.get_client_keys(client_id).json().get("keys", [])
 

--- a/test/resources/conftest.py
+++ b/test/resources/conftest.py
@@ -11,6 +11,16 @@ username = "janedoe"
 
 
 @pytest.fixture
+def maskinporten_create_client_body():
+    return {
+        "name": "some-client",
+        "description": "Very cool client",
+        "scopes": ["folkeregister:deling/offentligmedhjemmel"],
+        "env": "test",
+    }
+
+
+@pytest.fixture
 def maskinporten_create_client_response():
     return {
         "client_name": "some-client",


### PR DESCRIPTION
Roll back newly created Maskinporten clients when the call to create new permissions with the permission API fails.