### PR TITLE
T#145 Add option for returning keys to the client

### DIFF
--- a/maskinporten_api/ssm.py
+++ b/maskinporten_api/ssm.py
@@ -1,5 +1,4 @@
 import os
-from dataclasses import dataclass, asdict
 
 import boto3
 from botocore.exceptions import ClientError
@@ -12,64 +11,55 @@ def get_secret(key):
     return response["Parameter"]["Value"]
 
 
-@dataclass
-class Secrets:
-    keystore: str
-    key_id: str
-    key_password: str
-
-
 class AssumeRoleAccessDeniedException(Exception):
     """Raised when assume role request to aws fails with an access denied error"""
 
     pass
 
 
-class SendSecretsService:
-    def __init__(self):
-        self.sts_client = boto3.client("sts")
+def send_secrets(
+    secrets: dict,
+    maskinporten_client_id: str,
+    destination_aws_account_id: str,
+    destination_aws_region: str,
+):
+    """Send secret values to another AWS account.
 
-    def send_secrets(
-        self,
-        secrets: Secrets,
-        maskinporten_client_id,
-        destination_aws_account_id,
-        destination_aws_region,
-    ):
-        """Send secret values to another AWS Account.
+    Secret values are stored as SecureString SSM parameters with prefix
+    '/okdata/maskinporten/`maskinporten_client_id`/' in AWS account with ID
+    `destination_aws_account_id`.
 
-        Secret values are stored as SecureString SSM parameters with prefix
-        '/okdata/maskinporten/`maskinporten_client_id`/' in AWS account with ID
-        `destination_aws_account_id`.
-        """
-
-        role_arn = (
-            f"arn:aws:iam::{destination_aws_account_id}:role/dataplatform-maskinporten"
+    Return a list of the created SSM parameters.
+    """
+    try:
+        assume_role_response = boto3.client("sts").assume_role(
+            RoleArn=f"arn:aws:iam::{destination_aws_account_id}:role/dataplatform-maskinporten",
+            RoleSessionName="dataplatform-maskinporten",
         )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "AccessDenied":
+            raise AssumeRoleAccessDeniedException(e.response["Error"]["Message"])
+        raise e
 
-        try:
-            assume_role_response = self.sts_client.assume_role(
-                RoleArn=role_arn, RoleSessionName="dataplatform-maskinporten"
-            )
-        except ClientError as e:
-            if e.response["Error"]["Code"] == "AccessDenied":
-                raise AssumeRoleAccessDeniedException(e.response["Error"]["Message"])
-            raise e
+    credentials = assume_role_response["Credentials"]
 
-        credentials = assume_role_response["Credentials"]
+    ssm_client = boto3.client(
+        "ssm",
+        region_name=destination_aws_region,
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
+    )
 
-        ssm_client = boto3.client(
-            "ssm",
-            region_name=destination_aws_region,
-            aws_access_key_id=credentials["AccessKeyId"],
-            aws_secret_access_key=credentials["SecretAccessKey"],
-            aws_session_token=credentials["SessionToken"],
+    ssm_params = []
+    for key, value in secrets.items():
+        path = f"/okdata/maskinporten/{maskinporten_client_id}/{key}"
+        ssm_client.put_parameter(
+            Name=path,
+            Value=value,
+            Type="SecureString",
+            Overwrite=True,
         )
+        ssm_params.append(path)
 
-        for key, value in asdict(secrets).items():
-            ssm_client.put_parameter(
-                Name=f"/okdata/maskinporten/{maskinporten_client_id}/{key}",
-                Value=value,
-                Type="SecureString",
-                Overwrite=True,
-            )
+    return ssm_params

--- a/models/models.py
+++ b/models/models.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from enum import Enum
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -27,12 +28,15 @@ class MaskinportenClientOut(BaseModel):
 
 
 class CreateClientKeyIn(BaseModel):
-    destination_aws_account: str
-    destination_aws_region: str
+    destination_aws_account: Optional[str]
+    destination_aws_region: Optional[str]
 
 
 class CreateClientKeyOut(BaseModel):
     kid: str
+    ssm_params: Optional[list[str]]
+    keystore: Optional[str]
+    key_password: Optional[str]
 
 
 class DeleteClientKeyOut(BaseModel):

--- a/resources/maskinporten_clients.py
+++ b/resources/maskinporten_clients.py
@@ -167,8 +167,9 @@ def create_client_key(
     key_password = generate_password(pw_length=32)
     keystore = pkcs12_from_key(key, key_password)
     ssm_params = None
+    send_to_aws = body.destination_aws_account and body.destination_aws_region
 
-    if body.destination_aws_account:
+    if send_to_aws:
         try:
             ssm_params = send_secrets(
                 secrets={
@@ -204,8 +205,8 @@ def create_client_key(
     return CreateClientKeyOut(
         kid=kid,
         ssm_params=ssm_params,
-        keystore=None if body.destination_aws_account else keystore,
-        key_password=None if body.destination_aws_account else key_password,
+        keystore=None if send_to_aws else keystore,
+        key_password=None if send_to_aws else key_password,
     )
 
 


### PR DESCRIPTION
Return newly created keys back to the client if no destination AWS account is given.