### PR TITLE
T#170 Retract new keys on secrets injection error

### DIFF
--- a/resources/authorizer.py
+++ b/resources/authorizer.py
@@ -1,4 +1,5 @@
 import os
+from typing import Optional
 
 from fastapi import Depends
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -29,7 +30,7 @@ http_bearer = HTTPBearer(scheme_name="Keycloak token")
 
 
 class ServiceClient:
-    authorization_header: str
+    authorization_header: dict
 
     def __init__(
         self,
@@ -58,7 +59,7 @@ class AuthInfo:
         self.bearer_token = authorization.credentials
 
 
-def authorize(scope: str, resource: str = None):
+def authorize(scope: str, resource: Optional[str] = None):
     def _verify_permission(
         auth_info: AuthInfo = Depends(),
         resource_authorizer: ResourceAuthorizer = Depends(resource_authorizer),


### PR DESCRIPTION
Make the key creation procedure more robust by changing the flow from:

1) Assume AWS role *and* write parameters to SSM.
2) Create key in Maskinporten.

To:

1) Assume AWS role (first, since it's most likely to fail).
2) Create key in Maskinporten. If this fails, no harm done.
3) Write parameters to SSM. Delete the key again from Maskinporten if that fails somehow.