### PR TITLE
T#182 Insource client name construction

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -11,8 +11,9 @@ class MaskinportenEnvironment(str, Enum):
 
 
 class MaskinportenClientIn(BaseModel):
-    name: str
-    description: str
+    team_id: str
+    provider: str
+    integration: str
     scopes: list[str]
     env: MaskinportenEnvironment
 

--- a/resources/maskinporten.py
+++ b/resources/maskinporten.py
@@ -62,9 +62,14 @@ def create_client(
 ):
     authorize(auth_info, scope="maskinporten:client:create")
 
+    # TODO: Look up the actual team name here instead of using the (unreadable)
+    #       team ID once permission-api is extended to support it (T#179).
+    team_name = body.team_id
+
     logger.debug(
         sanitize(
-            f"Creating new client '{body.name}' in {body.env} with scopes {body.scopes}"
+            f"Creating new {body.provider} client for team '{team_name}' in "
+            "{body.env} with scopes {body.scopes}"
         )
     )
     try:
@@ -72,7 +77,9 @@ def create_client(
     except UnsupportedEnvironmentError as e:
         raise ErrorResponse(status.HTTP_400_BAD_REQUEST, str(e))
 
-    new_client = maskinporten_client.create_client(body).json()
+    new_client = maskinporten_client.create_client(
+        team_name, body.provider, body.integration, body.scopes
+    ).json()
     new_client_id = new_client["client_id"]
 
     try:

--- a/test/maskinporten_api/test_maskinporten_client.py
+++ b/test/maskinporten_api/test_maskinporten_client.py
@@ -1,0 +1,28 @@
+from maskinporten_api.maskinporten_client import MaskinportenClient
+
+
+def test_slugify_team_name():
+    assert MaskinportenClient._slugify_team_name("Datapatruljen") == "datapatruljen"
+    assert MaskinportenClient._slugify_team_name("Min Side") == "min-side"
+    assert (
+        MaskinportenClient._slugify_team_name("Kjøremiljø og verktøy!!!")
+        == "kjøremiljø-og-verktøy"
+    )
+
+
+def test_make_client_name():
+    assert (
+        MaskinportenClient._make_client_name(
+            "Skjemautvikling", "krr", "dvd-nae-fagprosess"
+        )
+        == "skjemautvikling-krr-dvd-nae-fagprosess"
+    )
+
+
+def test_make_client_description():
+    assert (
+        MaskinportenClient._make_client_description(
+            "Min side", "freg", "tjenesteprofil"
+        )
+        == "Freg-klient for tjenesteprofil (Min side)"
+    )

--- a/test/resources/conftest.py
+++ b/test/resources/conftest.py
@@ -66,7 +66,7 @@ def generate_mock_client_response(
 ):
     return {
         "client_name": client_name,
-        "description": "Very cool client",
+        "description": "Freg-klient for testing (My team)",
         "scopes": scopes,
         "authorization_lifetime": 0,
         "access_token_lifetime": 0,
@@ -88,8 +88,9 @@ def generate_mock_client_response(
 @pytest.fixture
 def maskinporten_create_client_body():
     return {
-        "name": "some-client",
-        "description": "Very cool client",
+        "team_id": "2cac0456-372f-d20a-054e-f9df155bb2f9",
+        "provider": "freg",
+        "integration": "testing",
         "scopes": ["folkeregister:deling/offentligmedhjemmel"],
         "env": "test",
     }
@@ -99,7 +100,7 @@ def maskinporten_create_client_body():
 def maskinporten_create_client_response():
     return generate_mock_client_response(
         client_id="d1427568-1eba-1bf2-59ed-1c4af065f30e",
-        client_name="some-client",
+        client_name="my-team-freg-testing",
     )
 
 

--- a/test/resources/test_maskinporten.py
+++ b/test/resources/test_maskinporten.py
@@ -1,10 +1,10 @@
 import os
-import pytest
-import requests_mock
 from unittest.mock import ANY
 
-from maskinporten_api.maskinporten_client import env_config
+import pytest
+import requests_mock
 
+from maskinporten_api.maskinporten_client import env_config
 from resources import maskinporten
 from test.mock_utils import mock_access_token_generation_requests
 from test.resources.conftest import get_mock_user, valid_client_token
@@ -43,8 +43,8 @@ def test_create_client(
 
     client = {
         "client_id": "d1427568-1eba-1bf2-59ed-1c4af065f30e",
-        "client_name": "some-client",
-        "description": "Very cool client",
+        "client_name": "my-team-freg-testing",
+        "description": "Freg-klient for testing (My team)",
         "scopes": ["folkeregister:deling/offentligmedhjemmel"],
         "created": "2021-09-15T10:20:43.354000+02:00",
         "last_updated": "2021-09-15T10:20:43.354000+02:00",
@@ -131,8 +131,8 @@ def test_list_clients(mock_client, mock_authorizer, maskinporten_get_clients_res
     assert response.json() == [
         {
             "client_id": "d1427568-1eba-1bf2-59ed-1c4af065f30e",
-            "client_name": "some-client",
-            "description": "Very cool client",
+            "client_name": "my-team-freg-testing",
+            "description": "Freg-klient for testing (My team)",
             "scopes": ["folkeregister:deling/offentligmedhjemmel"],
             "created": "2021-09-15T10:20:43.354000+02:00",
             "last_updated": "2021-09-15T10:20:43.354000+02:00",


### PR DESCRIPTION
Construct client names in the client creation endpoint instead of outsourcing it to the API user.