### PR TITLE
Fix client key audit trails

### DIFF
--- a/maskinporten_api/audit.py
+++ b/maskinporten_api/audit.py
@@ -7,7 +7,7 @@ from botocore.exceptions import ClientError
 log = logging.getLogger()
 
 
-def audit_log(item_id, item_type, env, action, user, scopes=None, client_id=None):
+def audit_log(item_id, item_type, env, action, user, scopes=None, key_id=None):
     """Add a log entry to the API's audit trail."""
 
     dynamodb = boto3.resource("dynamodb", region_name="eu-west-1")
@@ -23,7 +23,7 @@ def audit_log(item_id, item_type, env, action, user, scopes=None, client_id=None
                 "User": user,
                 "Timestamp": datetime.now(timezone.utc).isoformat(),
                 **({"Scopes": ",".join(scopes)} if scopes else {}),
-                **({"ClientId": client_id} if client_id else {}),
+                **({"KeyId": key_id} if key_id else {}),
             }
         )
     except ClientError as e:

--- a/resources/maskinporten.py
+++ b/resources/maskinporten.py
@@ -206,7 +206,7 @@ def create_client_key(
             raise ErrorResponse(status.HTTP_422_UNPROCESSABLE_ENTITY, str(e))
 
     try:
-        jwks = maskinporten_client.create_client_key(client_id, jwk).json()
+        maskinporten_client.create_client_key(client_id, jwk).json()
     except TooManyKeysError as e:
         raise ErrorResponse(status.HTTP_409_CONFLICT, str(e))
 
@@ -227,19 +227,17 @@ def create_client_key(
                 status.HTTP_500_INTERNAL_SERVER_ERROR, "Internal server error"
             )
 
-    kid = jwks["keys"][0]["kid"]
-
     audit_log(
-        item_id=kid,
-        item_type="key",
+        item_id=client_id,
+        item_type="client",
         env=env,
-        action="create",
+        action="add-key",
         user=auth_info.principal_id,
-        client_id=client_id,
+        key_id=key_id,
     )
 
     return CreateClientKeyOut(
-        kid=kid,
+        kid=key_id,
         ssm_params=ssm_params,
         keystore=None if send_to_aws else keystore,
         key_password=None if send_to_aws else key_password,
@@ -290,12 +288,12 @@ def delete_client_key(
         raise ErrorResponse(status.HTTP_404_NOT_FOUND, str(e))
 
     audit_log(
-        item_id=key_id,
-        item_type="key",
+        item_id=client_id,
+        item_type="client",
         env=env,
-        action="delete",
+        action="remove-key",
         user=auth_info.principal_id,
-        client_id=client_id,
+        key_id=key_id,
     )
 
 

--- a/test/resources/conftest.py
+++ b/test/resources/conftest.py
@@ -125,7 +125,7 @@ def maskinporten_create_client_key_response():
     return {
         "keys": [
             {
-                "kid": "1970-01-01-12-00-00",
+                "kid": "1970-01-01-01-00-00",
                 "alg": "RS256",
                 "n": "nYFc81LY5FoxWcKh",
                 "e": "AQAB",

--- a/test/resources/test_maskinporten.py
+++ b/test/resources/test_maskinporten.py
@@ -3,6 +3,7 @@ import pytest
 import requests_mock
 from unittest.mock import ANY
 
+from freezegun import freeze_time
 from maskinporten_api.maskinporten_client import env_config
 
 from resources import maskinporten
@@ -194,6 +195,7 @@ def test_list_clients_validation_error(
     )
 
 
+@freeze_time("1970-01-01")
 def test_create_client_key_to_aws(
     maskinporten_create_client_key_response,
     maskinporten_get_client_response,
@@ -237,7 +239,7 @@ def test_create_client_key_to_aws(
     assert res.status_code == 201
     key = res.json()
     assert key == {
-        "kid": "1970-01-01-12-00-00",
+        "kid": "1970-01-01-01-00-00",
         "key_password": None,
         "keystore": None,
         "ssm_params": [
@@ -253,11 +255,12 @@ def test_create_client_key_to_aws(
     )
 
     table = mock_dynamodb.Table("maskinporten-audit-trail")
-    audit_log_entry = table.get_item(Key={"Id": key["kid"], "Type": "key"})
-    assert audit_log_entry["Item"]["Id"] == key["kid"]
-    assert audit_log_entry["Item"]["Action"] == "create"
+    audit_log_entry = table.get_item(Key={"Id": client_id, "Type": "client"})
+    assert audit_log_entry["Item"]["Action"] == "add-key"
+    assert audit_log_entry["Item"]["KeyId"] == key["kid"]
 
 
+@freeze_time("1970-01-01")
 def test_create_client_key_return_to_client(
     maskinporten_create_client_key_response,
     maskinporten_get_client_response,
@@ -293,7 +296,7 @@ def test_create_client_key_return_to_client(
 
     assert res.status_code == 201
     key = res.json()
-    assert key["kid"] == "1970-01-01-12-00-00"
+    assert key["kid"] == "1970-01-01-01-00-00"
     assert isinstance(key["key_password"], str)
     assert isinstance(key["keystore"], str)
     assert not key["ssm_params"]
@@ -301,9 +304,9 @@ def test_create_client_key_return_to_client(
     maskinporten.ForeignAccountSecretsClient.send_secrets.assert_not_called()
 
     table = mock_dynamodb.Table("maskinporten-audit-trail")
-    audit_log_entry = table.get_item(Key={"Id": key["kid"], "Type": "key"})
-    assert audit_log_entry["Item"]["Id"] == key["kid"]
-    assert audit_log_entry["Item"]["Action"] == "create"
+    audit_log_entry = table.get_item(Key={"Id": client_id, "Type": "client"})
+    assert audit_log_entry["Item"]["Action"] == "add-key"
+    assert audit_log_entry["Item"]["KeyId"] == key["kid"]
 
 
 def test_create_client_key_too_many_keys(
@@ -415,7 +418,7 @@ def test_delete_client_key_last_remaining(
     mocker,
 ):
     client_id = "d1427568-1eba-1bf2-59ed-1c4af065f30e"
-    key_id = "1970-01-01-12-00-00"
+    key_id = "1970-01-01-01-00-00"
 
     with requests_mock.Mocker(real_http=True) as rm:
         mock_access_token_generation_requests(rm)
@@ -437,9 +440,9 @@ def test_delete_client_key_last_remaining(
     assert res.status_code == 200
 
     table = mock_dynamodb.Table("maskinporten-audit-trail")
-    audit_log_entry = table.get_item(Key={"Id": key_id, "Type": "key"})
-    assert audit_log_entry["Item"]["Id"] == key_id
-    assert audit_log_entry["Item"]["Action"] == "delete"
+    audit_log_entry = table.get_item(Key={"Id": client_id, "Type": "client"})
+    assert audit_log_entry["Item"]["Action"] == "remove-key"
+    assert audit_log_entry["Item"]["KeyId"] == key_id
 
 
 def test_delete_client_key_more_than_one_left(
@@ -453,7 +456,7 @@ def test_delete_client_key_more_than_one_left(
     mocker,
 ):
     client_id = "d1427568-1eba-1bf2-59ed-1c4af065f30e"
-    key_id = "1970-01-01-12-00-00"
+    key_id = "1970-01-01-01-00-00"
 
     # Add a second key.
     maskinporten_list_client_keys_response["keys"].append(
@@ -482,9 +485,9 @@ def test_delete_client_key_more_than_one_left(
     assert res.status_code == 200
 
     table = mock_dynamodb.Table("maskinporten-audit-trail")
-    audit_log_entry = table.get_item(Key={"Id": key_id, "Type": "key"})
-    assert audit_log_entry["Item"]["Id"] == key_id
-    assert audit_log_entry["Item"]["Action"] == "delete"
+    audit_log_entry = table.get_item(Key={"Id": client_id, "Type": "client"})
+    assert audit_log_entry["Item"]["Action"] == "remove-key"
+    assert audit_log_entry["Item"]["KeyId"] == key_id
 
 
 def test_delete_client_key_no_keys(
@@ -498,7 +501,7 @@ def test_delete_client_key_no_keys(
     mocker,
 ):
     client_id = "d1427568-1eba-1bf2-59ed-1c4af065f30e"
-    key_id = "1970-01-01-12-00-00"
+    key_id = "1970-01-01-01-00-00"
 
     with requests_mock.Mocker(real_http=True) as rm:
         mock_access_token_generation_requests(rm)
@@ -534,7 +537,7 @@ def test_list_client_keys(
     assert response.status_code == 200
     assert response.json() == [
         {
-            "kid": "1970-01-01-12-00-00",
+            "kid": "1970-01-01-01-00-00",
             "client_id": client_id,
             "created": "2021-09-16T12:34:17.099000+02:00",
             "expires": "2022-09-16T12:34:17.099000+02:00",


### PR DESCRIPTION
Key IDs are no longer unique. Log key additions and deletions as modification on the client instead.