### PR TITLE
T#173 Optionally clean SSM when deleting client

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -2,9 +2,10 @@ from models.models import (
     ClientKeyMetadata,
     CreateClientKeyIn,
     CreateClientKeyOut,
+    DeleteMaskinportenClientIn,
+    DeleteMaskinportenClientOut,
     MaskinportenClientIn,
     MaskinportenClientOut,
-    DeleteMaskinportenClientOut,
     MaskinportenEnvironment,
 )
 
@@ -12,8 +13,9 @@ __all__ = [
     "ClientKeyMetadata",
     "CreateClientKeyIn",
     "CreateClientKeyOut",
+    "DeleteMaskinportenClientIn",
+    "DeleteMaskinportenClientOut",
     "MaskinportenClientIn",
     "MaskinportenClientOut",
-    "DeleteMaskinportenClientOut",
     "MaskinportenEnvironment",
 ]

--- a/models/models.py
+++ b/models/models.py
@@ -29,9 +29,14 @@ class MaskinportenClientOut(BaseModel):
     active: bool
 
 
-# TODO: Check if any keycloak resources needs to be deleted
+class DeleteMaskinportenClientIn(BaseModel):
+    aws_account: Optional[str]
+    aws_region: Optional[str]
+
+
 class DeleteMaskinportenClientOut(BaseModel):
     client_id: str
+    deleted_ssm_params: list[str]
 
 
 class CreateClientKeyIn(BaseModel):

--- a/resources/maskinporten.py
+++ b/resources/maskinporten.py
@@ -220,7 +220,7 @@ def delete_client(  # noqa: C901
             f"Client {client_id} cannot be deleted due to internal server error.",
         )
 
-    send_to_aws = body.aws_account and body.aws_region
+    send_to_aws = body and body.aws_account and body.aws_region
     if send_to_aws:
         try:
             secrets_client = ForeignAccountSecretsClient(

--- a/test/resources/test_maskinporten.py
+++ b/test/resources/test_maskinporten.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 import pytest
 import requests_mock
@@ -281,6 +282,126 @@ def test_list_clients_validation_error(
         response.json()["message"]
         == "Unsupported Maskinporten environment. Must be one of: test, prod"
     )
+
+
+def test_delete_client(
+    maskinporten_get_client_response,
+    mock_authorizer,
+    mock_aws,
+    mock_client,
+    mock_dynamodb,
+    mocker,
+):
+    client_id = "d1427568-1eba-1bf2-59ed-1c4af065f30e"
+
+    with requests_mock.Mocker(real_http=True) as rm:
+        mock_access_token_generation_requests(rm)
+
+        rm.get(
+            f"{CLIENTS_ENDPOINT}{client_id}",
+            json=maskinporten_get_client_response,
+        )
+        rm.get(f"{CLIENTS_ENDPOINT}{client_id}/jwks", json={})
+        rm.delete(f"{CLIENTS_ENDPOINT}{client_id}")
+        res = mock_client.delete(
+            f"/clients/test/{client_id}",
+            json={"aws_account": None, "aws_region": None},
+            headers={"Authorization": get_mock_user("janedoe").bearer_token},
+        )
+
+    assert res.status_code == 200
+    data = res.json()
+    assert data["client_id"] == client_id
+    assert data["deleted_ssm_params"] == []
+
+    table = mock_dynamodb.Table("maskinporten-audit-trail")
+    audit_log_entry = table.get_item(Key={"Id": client_id, "Type": "client"})
+    assert audit_log_entry["Item"]["Action"] == "delete"
+    assert audit_log_entry["Item"]["User"] == "janedoe"
+
+
+def test_delete_client_remaining_keys(
+    maskinporten_get_client_response,
+    maskinporten_list_client_keys_response,
+    mock_authorizer,
+    mock_aws,
+    mock_client,
+    mock_dynamodb,
+    mocker,
+):
+    client_id = "d1427568-1eba-1bf2-59ed-1c4af065f30e"
+
+    with requests_mock.Mocker(real_http=True) as rm:
+        mock_access_token_generation_requests(rm)
+
+        rm.get(
+            f"{CLIENTS_ENDPOINT}{client_id}",
+            json=maskinporten_get_client_response,
+        )
+        rm.get(
+            f"{CLIENTS_ENDPOINT}{client_id}/jwks",
+            json=maskinporten_list_client_keys_response,
+        )
+        rm.delete(f"{CLIENTS_ENDPOINT}{client_id}")
+        res = mock_client.delete(
+            f"/clients/test/{client_id}",
+            json={"aws_account": None, "aws_region": None},
+            headers={"Authorization": get_mock_user("janedoe").bearer_token},
+        )
+
+    assert res.status_code == 422
+
+
+@patch("resources.maskinporten.ForeignAccountSecretsClient")
+def test_delete_client_delete_from_ssm(
+    MockForeignAccountSecretsClient,
+    maskinporten_get_client_response,
+    mock_authorizer,
+    mock_aws,
+    mock_client,
+    mock_dynamodb,
+    mocker,
+):
+    client_id = "d1427568-1eba-1bf2-59ed-1c4af065f30e"
+    MockForeignAccountSecretsClient.return_value.delete_secrets.return_value = [
+        "key_id",
+        "keystore",
+        "key_alias",
+        "key_password",
+    ]
+
+    with requests_mock.Mocker(real_http=True) as rm:
+        mock_access_token_generation_requests(rm)
+
+        rm.get(
+            f"{CLIENTS_ENDPOINT}{client_id}",
+            json=maskinporten_get_client_response,
+        )
+        rm.get(f"{CLIENTS_ENDPOINT}{client_id}/jwks", json={})
+        rm.delete(f"{CLIENTS_ENDPOINT}{client_id}")
+
+        aws_account = "123456789876"
+        aws_region = "eu-west-1"
+        res = mock_client.delete(
+            f"/clients/test/{client_id}",
+            json={"aws_account": aws_account, "aws_region": aws_region},
+            headers={"Authorization": get_mock_user("janedoe").bearer_token},
+        )
+
+    assert res.status_code == 200
+    data = res.json()
+    assert data["client_id"] == client_id
+    assert set(data["deleted_ssm_params"]) == {
+        "key_id",
+        "keystore",
+        "key_alias",
+        "key_password",
+    }
+
+    table = mock_dynamodb.Table("maskinporten-audit-trail")
+    audit_log_entry = table.get_item(Key={"Id": client_id, "Type": "client"})
+    assert audit_log_entry["Item"]["Action"] == "delete"
+    assert audit_log_entry["Item"]["User"] == "janedoe"
 
 
 @freeze_time("1970-01-01")


### PR DESCRIPTION
Optionally clean out the key secrets in SSM belonging to a client when it's deleted.