### PR TITLE
Bump python-keycloak

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ python-jose==3.3.0
     # via
     #   okdata-maskinporten-api (setup.py)
     #   python-keycloak
-python-keycloak==0.24.0
+python-keycloak==1.8.0
     # via
     #   okdata-maskinporten-api (setup.py)
     #   okdata-sdk
@@ -110,6 +110,7 @@ typing-extensions==3.10.0.0
 urllib3==1.26.5
     # via
     #   botocore
+    #   python-keycloak
     #   requests
 wrapt==1.12.1
     # via aws-xray-sdk

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         # version 3.3.0 or higher explicitly to silence some deprecation
         # warnings.
         "python-jose>=3.3.0,<4.0.0",
-        "python-keycloak",
+        "python-keycloak>=1,<2",
         "requests>=2.26.0,<3.0.0",
         # We don't really need this, but AWS Lambda started including this
         # library in the Python 3.9 runtime, and `requests` will swap the


### PR DESCRIPTION
Require python-keycloak 1.x to fix 48 warnings during test runs.