### PR TITLE
T#282 Back up key rotation table to S3 too

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -53,7 +53,7 @@ skulle bli nødvendig.
 (PITR) er påslått for tabellen og muliggjør gjenopprettelse av tabelldataene til
 et hvilket som helst tidspunkt siste 35 dager. I tillegg trigges en
 [eksport](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DataExport.html)
-av tabellen til S3 én gang i måneden (se egen Lambda handler `jobs.backup.export_audit_trail`).
+av tabellen til S3 én gang i måneden (se egen Lambda handler `jobs.backup.export_tables`).
 
 ### `okdata-permission-api`
 

--- a/jobs/backup.py
+++ b/jobs/backup.py
@@ -5,31 +5,44 @@ import boto3
 from aws_xray_sdk.core import patch_all, xray_recorder
 from okdata.aws.logging import log_add, logging_wrapper
 
+from maskinporten_api.util import getenv
 
-BACKUP_BUCKET_NAME = os.environ["BACKUP_BUCKET_NAME"]
-BACKUP_BUCKET_PREFIX = os.environ["SERVICE_NAME"] + "/maskinporten-audit-trail"
+BACKUP_BUCKET_NAME = getenv("BACKUP_BUCKET_NAME")
+SERVICE_NAME = getenv("SERVICE_NAME")
+
+TABLE_NAMES = [
+    "maskinporten-audit-trail",
+    "maskinporten-key-rotation",
+]
 
 patch_all()
 
 
 @logging_wrapper
-@xray_recorder.capture("export_audit_trail")
-def export_audit_trail(event, context):
-    """Trigger export of the audit trail database to S3."""
+@xray_recorder.capture("export_tables")
+def export_tables(event, context):
+    """Trigger exports of Maskinporten related DynamoDB tables to S3."""
     dynamodb = boto3.client("dynamodb", region_name=os.environ["AWS_REGION"])
-    audit_trail_table = dynamodb.describe_table(TableName="maskinporten-audit-trail")
     dt_now = datetime.utcnow()
-    s3_prefix = f"{BACKUP_BUCKET_PREFIX}/{dt_now.year}-{dt_now.month}/"
+    results = []
 
-    export_response = dynamodb.export_table_to_point_in_time(
-        TableArn=audit_trail_table["Table"]["TableArn"],
-        S3Bucket=BACKUP_BUCKET_NAME,
-        S3Prefix=s3_prefix,
-        ExportFormat="DYNAMODB_JSON",
-    )["ExportDescription"]
+    for table_name in TABLE_NAMES:
+        table = dynamodb.describe_table(TableName=table_name)
+        s3_prefix = f"{SERVICE_NAME}/{table_name}/{dt_now.year}-{dt_now.month}/"
 
-    log_add(
-        s3_export_status=export_response["ExportStatus"],
-        s3_export_target_bucket=export_response["S3Bucket"],
-        s3_export_target_prefix=export_response["S3Prefix"],
-    )
+        response = dynamodb.export_table_to_point_in_time(
+            TableArn=table["Table"]["TableArn"],
+            S3Bucket=BACKUP_BUCKET_NAME,
+            S3Prefix=s3_prefix,
+            ExportFormat="DYNAMODB_JSON",
+        )["ExportDescription"]
+
+        results.append(
+            {
+                "s3_export_status": response["ExportStatus"],
+                "s3_export_target_bucket": response["S3Bucket"],
+                "s3_export_target_prefix": response["S3Prefix"],
+            }
+        )
+
+    log_add(results=results)

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -60,9 +60,10 @@ functions:
       - http: ANY /
       - http: ANY /{any+}
     timeout: 29
-  export-audit-trail:
-    handler: jobs.backup.export_audit_trail
+  export-tables:
+    handler: jobs.backup.export_tables
     events:
+      # Midnight at the first day of every month.
       - schedule: cron(0 0 1 * ? *)
     timeout: 30
   client-report-internal:


### PR DESCRIPTION
Generalize the S3 backup job to include the key rotation table as well.