### PR TITLE
T#291 Change audit logging format

### DIFF
--- a/jobs/client_report.py
+++ b/jobs/client_report.py
@@ -14,7 +14,11 @@ from maskinporten_api.maskinporten_client import (
     MaskinportenClient,
     UnsupportedEnvironmentError,
 )
-from maskinporten_api.permissions import get_resource_permissions, get_team_by_name
+from maskinporten_api.permissions import (
+    client_resource_name,
+    get_resource_permissions,
+    get_team_by_name,
+)
 from models import MaskinportenEnvironment
 from resources.authorizer import ServiceClient, keycloak_client
 
@@ -78,7 +82,7 @@ def _client_teams(client, env):
 
     try:
         permissions = get_resource_permissions(
-            f"maskinporten:client:{env}-{client_id}",
+            client_resource_name(env, client_id),
             service_client.authorization_header,
         )
     except HTTPError as e:

--- a/maskinporten_api/audit.py
+++ b/maskinporten_api/audit.py
@@ -9,7 +9,7 @@ from botocore.exceptions import ClientError
 log = logging.getLogger()
 
 
-def audit_log(item_id, item_type, env, action, user, scopes=None, key_id=None):
+def audit_log(item_id, action, user, scopes=None, key_id=None):
     """Add a log entry to the API's audit trail."""
 
     dynamodb = boto3.resource("dynamodb", region_name="eu-west-1")
@@ -19,11 +19,9 @@ def audit_log(item_id, item_type, env, action, user, scopes=None, key_id=None):
         db_response = table.put_item(
             Item={
                 "Id": item_id,
-                "Type": item_type,
-                "Env": env,
+                "Timestamp": datetime.now(timezone.utc).isoformat(),
                 "Action": action,
                 "User": user,
-                "Timestamp": datetime.now(timezone.utc).isoformat(),
                 **({"Scopes": ",".join(scopes)} if scopes else {}),
                 **({"KeyId": key_id} if key_id else {}),
             }

--- a/maskinporten_api/permissions.py
+++ b/maskinporten_api/permissions.py
@@ -48,6 +48,11 @@ def get_user_permissions(bearer_token):
     return res.json()
 
 
+def client_resource_name(env, client_id):
+    """Return the resource name used to identify a Maskinporten client."""
+    return f"maskinporten:client:{env}-{client_id}"
+
+
 # TODO: Use `okdata-sdk-python` team client for the two functions
 # below. Requires a better way of calling the SDK as an already authenticated
 # user (by using the access token, not requiring re-auth using

--- a/test/resources/conftest.py
+++ b/test/resources/conftest.py
@@ -209,11 +209,11 @@ def mock_dynamodb():
         TableName="maskinporten-audit-trail",
         KeySchema=[
             {"AttributeName": "Id", "KeyType": "HASH"},
-            {"AttributeName": "Type", "KeyType": "RANGE"},
+            {"AttributeName": "Timestamp", "KeyType": "RANGE"},
         ],
         AttributeDefinitions=[
             {"AttributeName": "Id", "AttributeType": "S"},
-            {"AttributeName": "Type", "AttributeType": "S"},
+            {"AttributeName": "Timestamp", "AttributeType": "S"},
         ],
         ProvisionedThroughput={
             "ReadCapacityUnits": 5,

--- a/test/resources/test_maskinporten.py
+++ b/test/resources/test_maskinporten.py
@@ -382,7 +382,6 @@ def test_delete_client_no_body(
     assert data["deleted_ssm_params"] == []
 
     table = mock_dynamodb.Table("maskinporten-audit-trail")
-    table = mock_dynamodb.Table("maskinporten-audit-trail")
     audit_log_entry = table.query(
         KeyConditionExpression=Key("Id").eq(
             client_resource_name(


### PR DESCRIPTION
Drop the `Type` and `Env` fields; these are now baked into the `Id` field together with the client ID in order to make it unique across environments.

Depends on https://github.com/oslokommune/dataplatform-config/pull/181.