### PR TITLE
T#293 Check membership in `get_team` response

### DIFF
--- a/maskinporten_api/permissions.py
+++ b/maskinporten_api/permissions.py
@@ -57,7 +57,7 @@ def client_resource_name(env, client_id):
 # below. Requires a better way of calling the SDK as an already authenticated
 # user (by using the access token, not requiring re-auth using
 # username/password).
-def get_user_team(team_id, bearer_token, has_role=None):
+def get_team(team_id, bearer_token, has_role=None):
     params = {}
 
     if has_role:

--- a/resources/maskinporten.py
+++ b/resources/maskinporten.py
@@ -30,8 +30,8 @@ from maskinporten_api.permissions import (
     client_resource_name,
     create_okdata_permissions,
     delete_okdata_permissions,
+    get_team,
     get_user_permissions,
-    get_user_team,
 )
 from maskinporten_api.ssm import (
     AssumeRoleAccessDeniedError,
@@ -66,9 +66,13 @@ def create_client(
     authorize(auth_info, scope="maskinporten:client:create")
 
     try:
-        team = get_user_team(
-            body.team_id, auth_info.bearer_token, has_role="origo-team"
+        team = get_team(
+            body.team_id,
+            auth_info.bearer_token,
+            has_role="origo-team",
         )
+        if "is_member" in team and not team["is_member"]:
+            raise ErrorResponse(status.HTTP_403_FORBIDDEN, "Forbidden")
     except requests.RequestException as e:
         log_exception(e)
         if e.response.status_code == status.HTTP_403_FORBIDDEN:

--- a/test/resources/conftest.py
+++ b/test/resources/conftest.py
@@ -154,7 +154,7 @@ def maskinporten_list_client_keys_response(maskinporten_create_client_key_respon
 
 @pytest.fixture
 def user_team_response():
-    return {"id": team_id, "name": "foobar"}
+    return {"id": team_id, "name": "foobar", "is_member": True}
 
 
 @pytest.fixture

--- a/test/resources/test_maskinporten.py
+++ b/test/resources/test_maskinporten.py
@@ -150,6 +150,37 @@ def test_create_client_no_create_permission(
 
 def test_create_client_not_team_member(
     maskinporten_create_client_body,
+    user_team_response,
+    mock_authorizer,
+    mock_aws,
+    mock_client,
+    mock_dynamodb,
+    mocker,
+):
+    with requests_mock.Mocker(real_http=True) as rm:
+        mock_user = get_mock_user("janedoe")
+        mock_access_token_generation_requests(rm)
+
+        create_client_matcher = rm.post(
+            CLIENTS_ENDPOINT, json=maskinporten_create_client_body
+        )
+        user_team_response["is_member"] = False
+        rm.get(
+            f"{OKDATA_PERMISSION_API_URL}/teams/{team_id}",
+            json=user_team_response,
+        )
+        res = mock_client.post(
+            "/clients",
+            json=maskinporten_create_client_body,
+            headers={"Authorization": mock_user.bearer_token},
+        )
+
+    assert create_client_matcher.call_count == 0
+    assert res.status_code == 403
+
+
+def test_create_client_403_from_permission_api(
+    maskinporten_create_client_body,
     mock_authorizer,
     mock_aws,
     mock_client,


### PR DESCRIPTION
The `get_team` endpoint no longer responds with 403 when the caller isn't a member of the team, but includes the membership status in the response payload instead.

Depends on https://github.com/oslokommune/okdata-permission-api/pull/57.