### PR TITLE
T#305 Respond with real key expiration times

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -56,9 +56,7 @@ class CreateClientKeyOut(BaseModel):
 class ClientKeyMetadata(BaseModel):
     kid: str
     client_id: str
-    created: datetime
     expires: datetime
-    last_updated: datetime
 
 
 class AuditLogEntry(BaseModel):

--- a/resources/maskinporten.py
+++ b/resources/maskinporten.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timezone
 
 import requests
 from botocore.exceptions import ClientError
@@ -478,20 +478,11 @@ def list_client_keys(
             )
         raise
 
-    if "keys" not in jwks:
-        return []
-
-    created = jwks["created"]
-    last_updated = jwks["last_updated"]
-    expires = datetime.fromisoformat(created) + timedelta(days=365)
-
     return [
         ClientKeyMetadata(
             kid=key["kid"],
             client_id=client_id,
-            created=created,
-            expires=expires,
-            last_updated=last_updated,
+            expires=datetime.fromtimestamp(int(key["exp"]), tz=timezone.utc),
         )
-        for key in jwks["keys"]
+        for key in jwks.get("keys", [])
     ]

--- a/test/resources/conftest.py
+++ b/test/resources/conftest.py
@@ -130,7 +130,7 @@ def maskinporten_create_client_key_response():
                 "n": "nYFc81LY5FoxWcKh",
                 "e": "AQAB",
                 "kty": "RSA",
-                "exp": 1663324457,
+                "exp": 1577836800,
             }
         ],
         "last_updated": "2021-09-16T12:34:17.099+02:00",

--- a/test/resources/test_maskinporten.py
+++ b/test/resources/test_maskinporten.py
@@ -1065,11 +1065,30 @@ def test_list_client_keys(
         {
             "kid": "kid-1970-01-01-01-00-00",
             "client_id": client_id,
-            "created": "2021-09-16T12:34:17.099000+02:00",
-            "expires": "2022-09-16T12:34:17.099000+02:00",
-            "last_updated": "2021-09-16T12:34:17.099000+02:00",
+            "expires": "2020-01-01T00:00:00+00:00",
         }
     ]
+
+
+def test_list_client_keys_empty(
+    mock_client, mock_authorizer, maskinporten_list_client_keys_response
+):
+    client_id = "d1427568-1eba-1bf2-59ed-1c4af065f30e"
+
+    with requests_mock.Mocker(real_http=True) as rm:
+        mock_access_token_generation_requests(rm)
+        del maskinporten_list_client_keys_response["keys"]
+        rm.get(
+            f"{CLIENTS_ENDPOINT}{client_id}/jwks",
+            json=maskinporten_list_client_keys_response,
+        )
+        response = mock_client.get(
+            f"/clients/test/{client_id}/keys",
+            headers={"Authorization": get_mock_user("janedoe").bearer_token},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == []
 
 
 def test_list_client_keys_no_permission_for_resource(mock_client, mock_authorizer):


### PR DESCRIPTION
Respond with the real key expiration times from the key listing endpoint.

Keys are no longer renewed when the `jwks` object is updated, so we can't simply count on them expiring a year from the last update time.