### PR TITLE
Make key writes to SSM atomic

### DIFF
--- a/maskinporten_api/ssm.py
+++ b/maskinporten_api/ssm.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import boto3
@@ -90,28 +91,47 @@ class ForeignAccountSecretsClient:
         return self._send_secrets(
             [
                 {
+                    "name": "key.json",
+                    "value": json.dumps(
+                        {
+                            "key_id": key.jwk["kid"],
+                            "keystore": key.keystore,
+                            "key_alias": key.alias,
+                            "key_password": key.password,
+                        }
+                    ),
+                    "description": (
+                        f"[{env}] {client_name}: JSON-encoded string "
+                        "containing the key ID, the PKCS #12 archive "
+                        "containing the key, the alias of the key in the "
+                        "keystore, and the key password."
+                    ),
+                },
+                # TODO: Remove these four after all users have migrated away
+                # from them.
+                {
                     "name": "key_id",
                     "value": key.jwk["kid"],
-                    "description": f"[{env}] {client_name}: Key ID",
+                    "description": f"(Deprecated) [{env}] {client_name}: Key ID",
                 },
                 {
                     "name": "keystore",
                     "value": key.keystore,
                     "description": (
-                        f"[{env}] {client_name}: PKCS #12 archive " "containing the key"
+                        f"(Deprecated) [{env}] {client_name}: PKCS #12 archive containing the key"
                     ),
                 },
                 {
                     "name": "key_alias",
                     "value": key.alias,
                     "description": (
-                        f"[{env}] {client_name}: Alias of the key in the " "keystore"
+                        f"(Deprecated) [{env}] {client_name}: Alias of the key in the keystore"
                     ),
                 },
                 {
                     "name": "key_password",
                     "value": key.password,
-                    "description": f"[{env}] {client_name}: Key password",
+                    "description": f"(Deprecated) [{env}] {client_name}: Key password",
                 },
             ]
         )

--- a/resources/maskinporten.py
+++ b/resources/maskinporten.py
@@ -248,7 +248,7 @@ def delete_client(  # noqa: C901
     if send_to_aws:
         try:
             deleted_ssm_params = secrets_client.delete_secrets(
-                ["key_id", "keystore", "key_alias", "key_password"]
+                ["key.json", "key_id", "keystore", "key_alias", "key_password"]
             )
         except ClientError:
             # Secrets deletion failed. The client is informed by the returned

--- a/test/resources/test_maskinporten.py
+++ b/test/resources/test_maskinporten.py
@@ -476,6 +476,7 @@ def test_delete_client_delete_from_ssm(
     env = "test"
     client_id = "d1427568-1eba-1bf2-59ed-1c4af065f30e"
     MockForeignAccountSecretsClient.return_value.delete_secrets.return_value = [
+        "key.json",
         "key_id",
         "keystore",
         "key_alias",
@@ -505,6 +506,7 @@ def test_delete_client_delete_from_ssm(
     data = res.json()
     assert data["client_id"] == client_id
     assert set(data["deleted_ssm_params"]) == {
+        "key.json",
         "key_id",
         "keystore",
         "key_alias",
@@ -649,6 +651,7 @@ def test_create_client_key_to_aws(
         "kid": "kid-1970-01-01-01-00-00",
         "expires": "1970-04-01T00:00:00+00:00",
         "ssm_params": [
+            f"/okdata/maskinporten/{client_id}/key.json",
             f"/okdata/maskinporten/{client_id}/key_id",
             f"/okdata/maskinporten/{client_id}/keystore",
             f"/okdata/maskinporten/{client_id}/key_alias",
@@ -665,7 +668,7 @@ def test_create_client_key_to_aws(
         for s in maskinporten.ForeignAccountSecretsClient._send_secrets.call_args[0][
             1:
         ][0]
-    } == {"key_id", "keystore", "key_alias", "key_password"}
+    } == {"key.json", "key_id", "keystore", "key_alias", "key_password"}
 
     table = mock_dynamodb.Table("maskinporten-audit-trail")
     audit_log_entry = table.query(
@@ -730,6 +733,7 @@ def test_create_client_key_auto_rotate(
         "kid": "kid-1970-01-01-01-00-00",
         "expires": "1970-01-08T00:00:00+00:00",
         "ssm_params": [
+            f"/okdata/maskinporten/{client_id}/key.json",
             f"/okdata/maskinporten/{client_id}/key_id",
             f"/okdata/maskinporten/{client_id}/keystore",
             f"/okdata/maskinporten/{client_id}/key_alias",


### PR DESCRIPTION
Write secrets to a single JSON string in SSM instead of writing SSM secrets to individual paths. This reduces the number of calls users have to make to retrieve the necessary key data, plus that it removes the risk that details for different keys are read mid-rotation.