### PR TITLE
Change client delete action path

### DIFF
--- a/resources/maskinporten.py
+++ b/resources/maskinporten.py
@@ -168,8 +168,8 @@ def list_clients(env: MaskinportenEnvironment, auth_info: AuthInfo = Depends()):
     return clients
 
 
-@router.delete(
-    "/{env}/{client_id}",
+@router.post(
+    "/{env}/{client_id}/delete",
     status_code=status.HTTP_200_OK,
     response_model=DeleteMaskinportenClientOut,
     responses=error_message_models(
@@ -279,6 +279,30 @@ def delete_client(  # noqa: C901
         client_id=client_id,
         deleted_ssm_params=deleted_ssm_params,
     )
+
+
+# TODO: Delete this route after a grace period for CLI users to migrate to the
+#       new `POST /{env}/{client_id}/delete` path.
+@router.delete(
+    "/{env}/{client_id}",
+    status_code=status.HTTP_200_OK,
+    response_model=DeleteMaskinportenClientOut,
+    responses=error_message_models(
+        status.HTTP_400_BAD_REQUEST,
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+        status.HTTP_404_NOT_FOUND,
+        status.HTTP_422_UNPROCESSABLE_ENTITY,
+    ),
+)
+def delete_client_obsolete(
+    env: MaskinportenEnvironment,
+    body: DeleteMaskinportenClientIn = None,
+    client_id: str = Path(..., regex=r"^[0-9a-f-]+$"),
+    auth_info: AuthInfo = Depends(),
+    service_client: ServiceClient = Depends(),
+):
+    return delete_client(env, body, client_id, auth_info, service_client)
 
 
 @router.post(

--- a/test/resources/test_maskinporten.py
+++ b/test/resources/test_maskinporten.py
@@ -353,8 +353,8 @@ def test_delete_client(
         )
         rm.get(f"{CLIENTS_ENDPOINT}{client_id}/jwks", json={})
         rm.delete(f"{CLIENTS_ENDPOINT}{client_id}")
-        res = mock_client.delete(
-            f"/clients/{env}/{client_id}",
+        res = mock_client.post(
+            f"/clients/{env}/{client_id}/delete",
             json={"aws_account": None, "aws_region": None},
             headers={"Authorization": get_mock_user("janedoe").bearer_token},
         )
@@ -403,8 +403,8 @@ def test_delete_client_no_body(
         )
         rm.get(f"{CLIENTS_ENDPOINT}{client_id}/jwks", json={})
         rm.delete(f"{CLIENTS_ENDPOINT}{client_id}")
-        res = mock_client.delete(
-            f"/clients/{env}/{client_id}",
+        res = mock_client.post(
+            f"/clients/{env}/{client_id}/delete",
             headers={"Authorization": get_mock_user("janedoe").bearer_token},
         )
 
@@ -454,8 +454,8 @@ def test_delete_client_remaining_keys(
             json=maskinporten_list_client_keys_response,
         )
         rm.delete(f"{CLIENTS_ENDPOINT}{client_id}")
-        res = mock_client.delete(
-            f"/clients/test/{client_id}",
+        res = mock_client.post(
+            f"/clients/test/{client_id}/delete",
             json={"aws_account": None, "aws_region": None},
             headers={"Authorization": get_mock_user("janedoe").bearer_token},
         )
@@ -496,8 +496,8 @@ def test_delete_client_delete_from_ssm(
 
         aws_account = "123456789876"
         aws_region = "eu-west-1"
-        res = mock_client.delete(
-            f"/clients/{env}/{client_id}",
+        res = mock_client.post(
+            f"/clients/{env}/{client_id}/delete",
             json={"aws_account": aws_account, "aws_region": aws_region},
             headers={"Authorization": get_mock_user("janedoe").bearer_token},
         )
@@ -587,8 +587,8 @@ def test_delete_client_auto_rotate_disabled(
 
         rm.get(f"{CLIENTS_ENDPOINT}{client_id}/jwks", json={"keys": []})
 
-        res = mock_client.delete(
-            f"/clients/test/{client_id}",
+        res = mock_client.post(
+            f"/clients/test/{client_id}/delete",
             json={"aws_account": None, "aws_region": None},
             headers={"Authorization": get_mock_user("janedoe").bearer_token},
         )


### PR DESCRIPTION
Change the action path for deleting clients from `DELETE /{env}/{client_id}` to `POST /{env}/{client_id}/delete`.

Including a body in DELETE actions seems kind of discouraged, and isn't supported at all in some HTTP clients, so change it to a POST action instead.

The old endpoint is kept for a while to retain backwards compatibility.