### PR TITLE
Read secrets at runtime

### DIFF
--- a/jobs/client_report.py
+++ b/jobs/client_report.py
@@ -8,6 +8,7 @@ from itertools import chain
 import requests
 from aws_xray_sdk.core import patch_all, xray_recorder
 from okdata.aws.logging import logging_wrapper
+from okdata.aws.ssm import get_secret
 from requests.exceptions import HTTPError
 
 from maskinporten_api.auto_rotate import has_auto_rotate_enabled
@@ -151,7 +152,7 @@ def _send_email(to_emails, body):
             "emne": "Maskinporten klientrapport",
             "meldingskropp": body.replace("\n", "<br />"),
         },
-        headers={"apikey": os.environ["EMAIL_API_KEY"]},
+        headers={"apikey": get_secret("/dataplatform/shared/email-api-key")},
     )
     res.raise_for_status()
     return res

--- a/maskinporten_api/maskinporten_client.py
+++ b/maskinporten_api/maskinporten_client.py
@@ -6,9 +6,9 @@ import threading
 import requests
 from OpenSSL import crypto
 from botocore.exceptions import ClientError
+from okdata.aws.ssm import get_secret
 
 from maskinporten_api.jwt_client import JWTAuthClient, JWTConfig
-from maskinporten_api.ssm import get_secret
 from maskinporten_api.util import getenv
 from models import MaskinportenEnvironment
 

--- a/maskinporten_api/ssm.py
+++ b/maskinporten_api/ssm.py
@@ -1,18 +1,10 @@
 import json
-import os
 from datetime import datetime, timezone
 
 import boto3
 from botocore.exceptions import ClientError
 
 from maskinporten_api.keys import Key
-
-
-def get_secret(key):
-    """Return a secret (SecureString) from SSM stored under `key`."""
-    client = boto3.client("ssm", region_name=os.environ["AWS_REGION"])
-    response = client.get_parameter(Name=key, WithDecryption=True)
-    return response["Parameter"]["Value"]
 
 
 class AssumeRoleAccessDeniedError(Exception):

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,9 @@ authlib==0.15.4
 aws-xray-sdk==2.12.0
     # via okdata-maskinporten-api (setup.py)
 boto3==1.28.61
-    # via okdata-maskinporten-api (setup.py)
+    # via
+    #   okdata-aws
+    #   okdata-maskinporten-api (setup.py)
 botocore==1.31.61
     # via
     #   aws-xray-sdk
@@ -48,11 +50,11 @@ jsonschema==3.2.0
     # via okdata-sdk
 mangum==0.17.0
     # via okdata-maskinporten-api (setup.py)
-okdata-aws==1.0.1
+okdata-aws==2.1.0
     # via okdata-maskinporten-api (setup.py)
 okdata-resource-auth==0.1.4
     # via okdata-maskinporten-api (setup.py)
-okdata-sdk==0.9.2
+okdata-sdk==3.1.0
     # via okdata-aws
 pyasn1==0.4.8
     # via
@@ -78,6 +80,7 @@ python-dateutil==2.8.1
 python-jose==3.3.0
     # via
     #   okdata-maskinporten-api (setup.py)
+    #   okdata-sdk
     #   python-keycloak
 python-keycloak==1.8.0
     # via
@@ -117,6 +120,7 @@ typing-extensions==4.8.0
 urllib3==1.26.18
     # via
     #   botocore
+    #   okdata-sdk
     #   python-keycloak
     #   requests
 wrapt==1.15.0

--- a/resources/authorizer.py
+++ b/resources/authorizer.py
@@ -4,9 +4,9 @@ from typing import Optional
 from fastapi import Depends
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from keycloak import KeycloakOpenID
+from okdata.aws.ssm import get_secret
 from okdata.resource_auth import ResourceAuthorizer
 
-from maskinporten_api.ssm import get_secret
 from resources.errors import ErrorResponse
 
 

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -39,9 +39,7 @@ provider:
     OKDATA_PERMISSION_API_URL: ${ssm:/dataplatform/shared/api-gateway-url}/okdata-permission-api
     TIMEZONE: "Europe/Oslo"
     BACKUP_BUCKET_NAME: ${self:custom.backupBucket.${self:provider.stage}, self:custom.backupBucket.dev}
-    SLACK_MASKINPORTEN_API_ALERTS_WEBHOOK_URL: ${ssm:/dataplatform/slack/maskinporten-api-slack-webhook}
     EMAIL_API_URL: ${ssm:/dataplatform/shared/email-api-url}
-    EMAIL_API_KEY: ${ssm:/dataplatform/shared/email-api-key}
     KEY_ROTATION_GRACE_PERIOD_SECONDS: 300
     KEY_DEFAULT_EXPIRATION_DAYS: 90
     KEY_UNDER_ROTATION_EXPIRATION_DAYS: 7

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "cryptography>=41.0.4,<42",
         "fastapi>=0.109.2",
         "mangum>=0.12.4,<1",
-        "okdata-aws>=1.0.1,<2.0.0",
+        "okdata-aws>=2.1,<3",
         "okdata-resource-auth>=0.1.4",
         "pydantic>=1.10,<2",
         "pyjwt>=2.7,<3",

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -32,6 +32,11 @@ def initialize_parameter_store():
         Value="supersecretpassword",
         Type="SecureString",
     )
+    ssm_client.put_parameter(
+        Name="/dataplatform/slack/maskinporten-api-slack-webhook",
+        Value="http://hooks.slack.arpa/services/123",
+        Type="SecureString",
+    )
 
     for env in MaskinportenEnvironment:
         ssm_client.put_parameter(

--- a/test/maskinporten_api/test_ssm.py
+++ b/test/maskinporten_api/test_ssm.py
@@ -5,12 +5,12 @@ import pytest
 from botocore.exceptions import ClientError
 from freezegun import freeze_time
 from moto.sts.models import STSBackend
+from okdata.aws.ssm import get_secret
 
 from maskinporten_api.keys import create_key
 from maskinporten_api.ssm import (
     AssumeRoleAccessDeniedError,
     ForeignAccountSecretsClient,
-    get_secret,
 )
 
 

--- a/test/resources/test_maskinporten.py
+++ b/test/resources/test_maskinporten.py
@@ -16,7 +16,7 @@ from test.resources.conftest import get_mock_user, valid_client_token, team_id
 
 CLIENTS_ENDPOINT = env_config("test").maskinporten_clients_endpoint
 OKDATA_PERMISSION_API_URL = os.environ["OKDATA_PERMISSION_API_URL"]
-SLACK_WEBHOOK_URL = os.environ["SLACK_MASKINPORTEN_API_ALERTS_WEBHOOK_URL"]
+SLACK_WEBHOOK_URL = "http://hooks.slack.arpa/services/123"
 
 
 def test_create_client(

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ setenv =
     RESOURCE_SERVER_CLIENT_ID=some-resource-server
     OKDATA_PERMISSION_API_URL = https://example.com/okdata-permission-api
     BACKUP_BUCKET_NAME = backup-bucket
-    SLACK_MASKINPORTEN_API_ALERTS_WEBHOOK_URL = http://hooks.slack.arpa/services/123
     TIMEZONE = Europe/Oslo
     KEY_ROTATION_GRACE_PERIOD_SECONDS = 3
     KEY_DEFAULT_EXPIRATION_DAYS = 90


### PR DESCRIPTION
Don't hardcode the email API key and the Slack webhook URL in the Lambda environment, fetch them from SSM at runtime instead.