### PR TITLE
Update to 2025-05-22 version of Digdir's API

### DIFF
--- a/maskinporten_api/keys.py
+++ b/maskinporten_api/keys.py
@@ -54,6 +54,7 @@ def _jwk_from_key(key: rsa.RSAPrivateKey, expiration_days):
     return {
         "kid": now.strftime("kid-%Y-%m-%d-%H-%M-%S"),
         "alg": "RS256",
+        "use": "sig",
         **JsonWebKey.import_key(public_key),
         "exp": int(expiry.timestamp()),
     }

--- a/test/maskinporten_api/test_keys.py
+++ b/test/maskinporten_api/test_keys.py
@@ -12,6 +12,7 @@ def test_jwk_from_key():
 
     assert jwk["kid"] == "kid-1970-01-01-01-00-00"
     assert jwk["alg"] == "RS256"
+    assert jwk["use"] == "sig"
     assert isinstance(jwk["n"], str)
     assert isinstance(jwk["e"], str)
     assert jwk["kty"] == "RSA"

--- a/test/resources/conftest.py
+++ b/test/resources/conftest.py
@@ -180,6 +180,7 @@ def maskinporten_create_client_key_response():
             {
                 "kid": "kid-1970-01-01-01-00-00",
                 "alg": "RS256",
+                "use": "sig",
                 "n": "nYFc81LY5FoxWcKh",
                 "e": "AQAB",
                 "kty": "RSA",


### PR DESCRIPTION
Digdir launched a new version of the Maskinporten API at 2025-05-22.

The notable changes for us are:

- New base URLs: https://api.test.samarbeid.digdir.no/api/v1/clients and https://api.samarbeid.digdir.no/api/v1/clients versus the old https://api.test.samarbeid.digdir.no/clients/ and
https://api.samarbeid.digdir.no/clients/ (note that the trailing slash is gone).

- A `sig` field is required in the client key JWT payloads. Existing keys don't have this field, so it has to be patched in whenever we update existing keys.