### PR TITLE
Increase expiration time for auto-rotated keys

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -46,7 +46,7 @@ provider:
     EMAIL_API_URL: ${ssm:/dataplatform/shared/email-api-url}
     KEY_ROTATION_GRACE_PERIOD_SECONDS: 300
     KEY_DEFAULT_EXPIRATION_DAYS: 90
-    KEY_UNDER_ROTATION_EXPIRATION_DAYS: 7
+    KEY_UNDER_ROTATION_EXPIRATION_DAYS: 30
 
 functions:
   app:


### PR DESCRIPTION
Increase the expiration time for auto-rotated keys from 7 to 30 days. This gives us more slack for fixing the rotation job in case it breaks down, which is especially nice during the summer break.