### PR TITLE
Drop lifetime parameters for ID-Porten clients

### DIFF
--- a/maskinporten_api/maskinporten_client.py
+++ b/maskinporten_api/maskinporten_client.py
@@ -160,9 +160,7 @@ class MaskinportenClient:
             "POST",
             ["idporten:dcr.write"],
             json={
-                "access_token_lifetime": 0,
                 "application_type": "web",
-                "authorization_lifetime": 0,
                 "client_name": self._make_client_name(team_name, provider, integration),
                 "client_uri": str(client_uri),
                 "description": self._make_client_description(
@@ -177,7 +175,6 @@ class MaskinportenClient:
                     str(u) for u in post_logout_redirect_uris
                 ],
                 "redirect_uris": [str(u) for u in redirect_uris],
-                "refresh_token_lifetime": 0,
                 "refresh_token_usage": "ONETIME",
                 "scopes": ["openid", "profile"],
                 "sso_disabled": False,


### PR DESCRIPTION
Token lifetime parameters with value 0 would previously give us default values when creating ID-Porten clients.

Digdir has apparently changed the API to respond to 0 values with 400 Bad Request instead. By dropping the parameters altogether, we get default lifetime values again for new clients.