### PR TITLE
Upgrade to Python 3.13 + dependencies

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Install Python dependencies
       run: pip install tox
     - name: Test with tox

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Install Python dependencies
       run: pip install tox
     - name: Test with tox

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-    - name: Set up Python 3.11
+    - name: Set up Python 3.13
       uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435 # v4.5.0
       with:
-        python-version: '3.11'
+        python-version: '3.13'
     - name: Install dependencies
       run: pip install tox
     - name: Test with tox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/python:3.11
+FROM public.ecr.aws/lambda/python:3.13
 
 COPY jobs ${LAMBDA_TASK_ROOT}/jobs
 COPY maskinporten_api ${LAMBDA_TASK_ROOT}/maskinporten_api

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ['py311']
+target-version = ['py313']
 # Keep exclude in sync with flake8 config in tox.ini
 exclude = '''
 /(

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,20 +12,20 @@ attrs==25.3.0
     # via
     #   jsonschema
     #   referencing
-authlib==1.6.0
+authlib==1.6.1
     # via okdata-maskinporten-api (setup.py)
 aws-xray-sdk==2.14.0
     # via okdata-maskinporten-api (setup.py)
-boto3==1.38.46
+boto3==1.39.15
     # via
     #   okdata-aws
     #   okdata-maskinporten-api (setup.py)
-botocore==1.38.46
+botocore==1.39.15
     # via
     #   aws-xray-sdk
     #   boto3
     #   s3transfer
-certifi==2025.6.15
+certifi==2025.7.14
     # via requests
 cffi==1.17.1
     # via cryptography
@@ -38,7 +38,7 @@ cryptography==44.0.3
     #   okdata-maskinporten-api (setup.py)
 deprecation==2.1.0
     # via python-keycloak
-fastapi==0.115.14
+fastapi==0.116.1
     # via okdata-maskinporten-api (setup.py)
 idna==3.10
     # via
@@ -48,7 +48,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via okdata-sdk
 jsonschema-specifications==2025.4.1
     # via jsonschema
@@ -94,23 +94,23 @@ requests==2.32.4
     #   requests-toolbelt
 requests-toolbelt==1.0.0
     # via python-keycloak
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
     # via anyio
-starlette==0.46.2
+starlette==0.47.2
     # via
     #   fastapi
     #   okdata-aws
 structlog==25.4.0
     # via okdata-aws
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   fastapi
     #   jwcrypto

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setup(
         "python-keycloak",
         "requests>=2.28.0,<3",
     ],
-    python_requires="==3.11.*",
+    python_requires="==3.13.*",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py311, flake8, black
+envlist = py313, flake8, black
 
 [testenv]
 deps =
     freezegun
-    httpx==0.26.0  # `fastapi.testclient.TestClient` uses this
-    moto[dynamodb, ssm, sts]==3.1.0
+    httpx  # `fastapi.testclient.TestClient` uses this
+    moto[dynamodb, ssm, sts]==3.1.19
     pytest
     pytest-mock
     requests-mock


### PR DESCRIPTION
Upgrade the Lambda runtime to Python 3.13.

Also upgrade dependencies to get rid of known vulnerabilities.