### PR TITLE
Define `TeamMissingEmailWarning.__eq__`

### DIFF
--- a/jobs/client_report.py
+++ b/jobs/client_report.py
@@ -67,6 +67,9 @@ class TeamMissingEmailWarning(Exception):
     def __str__(self):
         return f"Team {self.team_name} har ingen epostadresse."
 
+    def __eq__(self, other):
+        return self.team_name == other.team_name
+
     def __hash__(self):
         return hash(self.team_name)
 


### PR DESCRIPTION
Add `__eq__` to the `TeamMissingEmailWarning` class to remove a warning from CodeQL (about `__hash__` being defined but not `__eq__`).